### PR TITLE
fix: title text readable in controls bar

### DIFF
--- a/ui/src/routes/fq2026/+page.svelte
+++ b/ui/src/routes/fq2026/+page.svelte
@@ -153,7 +153,7 @@
 <div class="flex flex-col h-full overflow-hidden">
     <header class="shrink-0 fqf-controls-bar px-4 py-2">
         <div class="flex items-center justify-between">
-            <h1 class="text-base font-semibold" style="color: var(--mg-purple-deep);">
+            <h1 class="text-base font-semibold" style="color: var(--mg-gold-bright);">
                 FQF 2026 Schedule Builder
             </h1>
             {#if isMobile && appState.viewMode !== 'my-schedule' && appState.viewMode !== 'share'}


### PR DESCRIPTION
The "FQF 2026 Schedule Builder" `h1` in the controls bar was styled with `--mg-purple-deep`, rendering it invisible against the purple controls bar background. Changed to `--mg-gold-bright` for readable contrast.

Fixes #4
