### PR TITLE
fix: only show conflict indicators on picked acts

### DIFF
--- a/ui/src/lib/components/MobileSchedule.svelte
+++ b/ui/src/lib/components/MobileSchedule.svelte
@@ -59,8 +59,10 @@
         return slots.map((slot) => ({ header: slotLabel(slot), acts: bySlot.get(slot)! }));
     });
 
+    const UNPICKED_BORDER_COLOR = 'transparent';
+
     function conflictColor(act: ActSummary): string {
-        if (!picks.has(act.slug)) return CONFLICT_COLORS.none;
+        if (!picks.has(act.slug)) return UNPICKED_BORDER_COLOR;
         const level: ConflictLevel = getWorstConflict(act, acts, picks);
         return CONFLICT_COLORS[level];
     }


### PR DESCRIPTION
In `MobileSchedule.svelte`, `conflictColor()` was returning `CONFLICT_COLORS.none` (green `#22c55e`) for unpicked acts. This caused every row to show a green left border, which conveyed no useful information and was visually noisy.

**Fix:** Return `transparent` for unpicked acts so the colored left border only appears on picked acts (green = no conflict, yellow/red = conflict).

**Other components checked:**
- `ActBlock.svelte` — already correct, `blockClass` gates all conflict CSS classes behind `isPicked`
- `MySchedule.svelte` — only renders picked acts, so no change needed

Fixes #7
