### PR TITLE
feat: My Schedule map mode with control bar, numbered markers, and path arrows

### DIFF
--- a/ui/src/lib/components/MapView.svelte
+++ b/ui/src/lib/components/MapView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import type { ActSummary } from '$lib/types';
+    import { FESTIVAL_DATES, DAY_LABELS } from '$lib/types';
     import {
         GRID_START_HOUR,
         GRID_END_HOUR,
@@ -7,32 +8,55 @@
         SCRUBBER_STEP_MINUTES,
         FESTIVAL_START_ISO
     } from '$lib/constants';
-    import { latLngToPercent, allStageStatuses, formatTimeDisplay } from '$lib/map-utils';
+    import {
+        latLngToPercent,
+        allStageStatuses,
+        formatTimeDisplay,
+        pickedActsForDay,
+        buildScheduleMarkers,
+        buildPathArrows,
+        markerFillColor,
+        formatTime12
+    } from '$lib/map-utils';
     import StageMarker from '$lib/components/StageMarker.svelte';
+
+    type MapMode = 'scroll' | 'now' | 'my-schedule';
 
     interface Props {
         acts: ActSummary[];
+        allActs: ActSummary[];
+        picks: Set<string>;
+        selectedDate: string;
         stageLocations: Map<string, { lat: number; lng: number }>;
         onActDetail?: (act: ActSummary) => void;
+        onDayChange?: (date: string) => void;
     }
 
-    let { acts, stageLocations, onActDetail }: Props = $props();
+    let { acts, allActs, picks, selectedDate, stageLocations, onActDetail, onDayChange }: Props =
+        $props();
 
     const SCRUBBER_START = GRID_START_HOUR * MINUTES_PER_HOUR;
     const SCRUBBER_END = GRID_END_HOUR * MINUTES_PER_HOUR;
     const DEFAULT_HOUR = 12;
     const DEFAULT_TIME = DEFAULT_HOUR * MINUTES_PER_HOUR;
     const NOW_UPDATE_MS = 60_000;
+    // Marker sizes in CSS px
+    const FIRST_MARKER_SIZE = 28;
+    const OTHER_MARKER_SIZE = 20;
+    // SVG arrow layout
+    const ARROW_MARKER_ID = 'fqf-path-arrow';
+    const ARROW_MIDPOINT = 0.5;
+    const LABEL_OFFSET_PX = 6;
 
+    let mapMode = $state<MapMode>('scroll');
     let manualMinutes = $state(DEFAULT_TIME);
-    let useNow = $state(false);
+    let showPaths = $state(false);
     let nowMinutes = $state(DEFAULT_TIME);
     let nowInterval: ReturnType<typeof setInterval> | null = null;
 
     function computeNowMinutes(): number {
         const festivalStart = new Date(FESTIVAL_START_ISO);
         const now = new Date();
-        // Before festival: clamp to festival start
         if (now < festivalStart) return SCRUBBER_START;
         const minutesSinceMidnight = now.getHours() * MINUTES_PER_HOUR + now.getMinutes();
         const rounded =
@@ -41,7 +65,7 @@
     }
 
     $effect(() => {
-        if (useNow) {
+        if (mapMode === 'now') {
             nowMinutes = computeNowMinutes();
             nowInterval = setInterval(() => {
                 nowMinutes = computeNowMinutes();
@@ -55,44 +79,114 @@
         };
     });
 
-    const currentMinutes = $derived(useNow ? nowMinutes : manualMinutes);
-    const statuses = $derived(allStageStatuses(acts, stageLocations, currentMinutes));
+    const currentMinutes = $derived(mapMode === 'now' ? nowMinutes : manualMinutes);
     const timeLabel = $derived(formatTimeDisplay(currentMinutes));
+
+    // Scroll / Now mode — existing stage-status markers
+    const statuses = $derived(
+        mapMode !== 'my-schedule' ? allStageStatuses(acts, stageLocations, currentMinutes) : []
+    );
+
+    // My Schedule mode
+    const orderedPicks = $derived(
+        mapMode === 'my-schedule'
+            ? pickedActsForDay(allActs, picks, selectedDate, stageLocations)
+            : []
+    );
+    const scheduleMarkers = $derived(
+        mapMode === 'my-schedule' ? buildScheduleMarkers(orderedPicks, stageLocations) : []
+    );
+    const pathArrows = $derived(
+        mapMode === 'my-schedule' && showPaths ? buildPathArrows(orderedPicks, stageLocations) : []
+    );
+
+    function markerLabel(order: number, act: ActSummary): string {
+        return `${order}  ${formatTime12(act.start)}–${formatTime12(act.end)}  ${act.name}`;
+    }
+
+    // SVG arrow: midpoint for label placement
+    function midpoint(
+        from: { x: number; y: number },
+        to: { x: number; y: number }
+    ): { x: number; y: number } {
+        return {
+            x: from.x + (to.x - from.x) * ARROW_MIDPOINT,
+            y: from.y + (to.y - from.y) * ARROW_MIDPOINT
+        };
+    }
+
+    function formatDistanceM(meters: number): string {
+        return `${Math.round(meters)}m`;
+    }
 </script>
 
 <div class="flex flex-col h-full overflow-hidden">
-    <!-- Time scrubber -->
-    <div class="fqf-time-scrubber flex items-center gap-3 px-4 py-2">
-        <span
-            class="text-sm font-semibold shrink-0"
-            style="color: var(--mg-purple-deep); min-width: 5.5rem;"
-        >
-            {timeLabel}
-        </span>
+    <!-- Control bar -->
+    <div class="fqf-time-scrubber shrink-0 flex flex-col gap-2 px-4 py-2">
+        <!-- Row 1: Day tabs + mode radio -->
+        <div class="flex items-center gap-4 flex-wrap">
+            <!-- Day selector -->
+            <div class="flex gap-1">
+                {#each FESTIVAL_DATES as d}
+                    <button
+                        class="fqf-day-tab {selectedDate === d ? 'fqf-day-tab-active' : ''}"
+                        onclick={() => onDayChange?.(d)}
+                    >
+                        {DAY_LABELS[d]}
+                    </button>
+                {/each}
+            </div>
 
-        {#if !useNow}
-            <input
-                type="range"
-                min={SCRUBBER_START}
-                max={SCRUBBER_END}
-                step={SCRUBBER_STEP_MINUTES}
-                bind:value={manualMinutes}
-                class="flex-1"
-                aria-label="Festival time"
-            />
-        {:else}
-            <span class="flex-1 text-xs italic" style="color: var(--mg-green-deep); opacity: 0.7;">
+            <!-- Triple radio -->
+            <div class="flex items-center gap-3 text-xs" style="color: var(--mg-purple-deep);">
+                {#each [{ value: 'scroll', label: 'Scroll Time' }, { value: 'now', label: 'Now' }, { value: 'my-schedule', label: 'My Schedule' }] as mode (mode.value)}
+                    <label class="flex items-center gap-1 cursor-pointer select-none">
+                        <input
+                            type="radio"
+                            name="map-mode"
+                            value={mode.value}
+                            checked={mapMode === mode.value}
+                            onchange={() => (mapMode = mode.value as MapMode)}
+                            class="accent-purple-700"
+                        />
+                        {mode.label}
+                    </label>
+                {/each}
+            </div>
+        </div>
+
+        <!-- Row 2: time scrubber (Scroll Time only) or Show Paths (My Schedule only) -->
+        {#if mapMode === 'scroll'}
+            <div class="flex items-center gap-3">
+                <span
+                    class="text-sm font-semibold shrink-0"
+                    style="color: var(--mg-purple-deep); min-width: 5.5rem;"
+                >
+                    {timeLabel}
+                </span>
+                <input
+                    type="range"
+                    min={SCRUBBER_START}
+                    max={SCRUBBER_END}
+                    step={SCRUBBER_STEP_MINUTES}
+                    bind:value={manualMinutes}
+                    class="flex-1"
+                    aria-label="Festival time"
+                />
+            </div>
+        {:else if mapMode === 'now'}
+            <span class="text-xs italic" style="color: var(--mg-green-deep); opacity: 0.7;">
                 Live clock (updates every minute)
             </span>
+        {:else}
+            <label
+                class="flex items-center gap-1.5 text-xs cursor-pointer select-none"
+                style="color: var(--mg-purple-deep);"
+            >
+                <input type="checkbox" bind:checked={showPaths} class="accent-purple-700" />
+                Show Paths
+            </label>
         {/if}
-
-        <label
-            class="flex items-center gap-1.5 text-xs shrink-0 cursor-pointer select-none"
-            style="color: var(--mg-purple-deep);"
-        >
-            <input type="checkbox" bind:checked={useNow} class="accent-purple-700" />
-            Now
-        </label>
     </div>
 
     <!-- Map container -->
@@ -105,14 +199,118 @@
                 draggable="false"
             />
 
-            <!-- Stage markers positioned by lat/lng -->
-            {#each statuses as status (status.stage)}
-                {@const loc = stageLocations.get(status.stage)}
-                {#if loc}
-                    {@const pos = latLngToPercent(loc.lat, loc.lng)}
-                    <StageMarker {status} {onActDetail} style="left: {pos.x}%; top: {pos.y}%;" />
+            {#if mapMode !== 'my-schedule'}
+                <!-- Scroll Time / Now: existing stage-status markers -->
+                {#each statuses as status (status.stage)}
+                    {@const loc = stageLocations.get(status.stage)}
+                    {#if loc}
+                        {@const pos = latLngToPercent(loc.lat, loc.lng)}
+                        <StageMarker
+                            {status}
+                            {onActDetail}
+                            style="left: {pos.x}%; top: {pos.y}%;"
+                        />
+                    {/if}
+                {/each}
+            {:else}
+                <!-- My Schedule: path arrows (SVG overlay) -->
+                {#if showPaths && pathArrows.length > 0}
+                    <svg
+                        class="absolute inset-0 w-full h-full pointer-events-none"
+                        style="overflow: visible;"
+                        aria-hidden="true"
+                    >
+                        <defs>
+                            <marker
+                                id={ARROW_MARKER_ID}
+                                markerWidth="8"
+                                markerHeight="8"
+                                refX="4"
+                                refY="2"
+                                orient="auto"
+                            >
+                                <path d="M0,0 L0,4 L6,2 z" fill="#7c3aed" />
+                            </marker>
+                        </defs>
+                        {#each pathArrows as arrow, i (i)}
+                            {@const mid = midpoint(arrow.from, arrow.to)}
+                            <line
+                                x1="{arrow.from.x}%"
+                                y1="{arrow.from.y}%"
+                                x2="{arrow.to.x}%"
+                                y2="{arrow.to.y}%"
+                                stroke="#7c3aed"
+                                stroke-width="2"
+                                stroke-dasharray="6 3"
+                                marker-end="url(#{ARROW_MARKER_ID})"
+                                opacity="0.75"
+                            />
+                            <text
+                                x="{mid.x}%"
+                                y="{mid.y}%"
+                                dy="-{LABEL_OFFSET_PX}"
+                                text-anchor="middle"
+                                font-size="9"
+                                fill="#7c3aed"
+                                font-weight="600"
+                            >
+                                {formatDistanceM(arrow.distanceMeters)}
+                            </text>
+                        {/each}
+                    </svg>
                 {/if}
-            {/each}
+
+                <!-- My Schedule: numbered act markers -->
+                {#each scheduleMarkers as marker (marker.act.slug)}
+                    {@const size = marker.isFirst ? FIRST_MARKER_SIZE : OTHER_MARKER_SIZE}
+                    {@const fill = markerFillColor(marker.isFirst, marker.conflict)}
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                    <div
+                        class="absolute -translate-x-1/2 -translate-y-full cursor-pointer"
+                        style="left: {marker.pos.x}%; top: {marker.pos.y}%;"
+                        onclick={(e) => {
+                            e.stopPropagation();
+                            onActDetail?.(marker.act);
+                        }}
+                        title={markerLabel(marker.order, marker.act)}
+                    >
+                        <div class="flex items-center gap-1 fqf-map-marker fqf-map-act-row">
+                            <!-- Numbered circle -->
+                            <div
+                                class="flex items-center justify-center rounded-full shrink-0 font-bold text-white"
+                                style="width: {size}px; height: {size}px; background: {fill}; font-size: {marker.isFirst
+                                    ? 12
+                                    : 10}px; box-shadow: 0 1px 4px rgba(0,0,0,0.35);"
+                            >
+                                {marker.order}
+                            </div>
+                            <!-- Label: time range + name -->
+                            <span
+                                class="text-[9px] font-medium truncate"
+                                style="max-width: 120px; color: var(--mg-text);"
+                            >
+                                {formatTime12(marker.act.start)}–{formatTime12(marker.act.end)}
+                                {marker.act.name}
+                            </span>
+                        </div>
+                        <div class="fqf-map-pin"></div>
+                    </div>
+                {/each}
+
+                {#if scheduleMarkers.length === 0}
+                    <div
+                        class="absolute inset-0 flex items-center justify-center pointer-events-none"
+                    >
+                        <p
+                            class="text-sm px-4 py-2 rounded"
+                            style="background: rgba(255,255,255,0.85); color: var(--mg-purple-deep);"
+                        >
+                            No picks for this day yet.
+                        </p>
+                    </div>
+                {/if}
+            {/if}
         </div>
     </div>
 </div>

--- a/ui/src/lib/map-utils.test.ts
+++ b/ui/src/lib/map-utils.test.ts
@@ -3,14 +3,21 @@ import type { ActSummary } from '$lib/types';
 import {
     parseTimeToMinutes,
     formatTimeDisplay,
+    formatTime12,
     latLngToPercent,
     stageStatusAt,
     allStageStatuses,
     countdownColor,
+    pickedActsForDay,
+    buildScheduleMarkers,
+    buildPathArrows,
+    markerFillColor,
+    MIN_PATH_DISTANCE_METERS,
+    SCHEDULE_MARKER_PURPLE,
     COUNTDOWN_GREEN,
     COUNTDOWN_GRAY
 } from '$lib/map-utils';
-import { MAP_BOUNDS } from '$lib/constants';
+import { MAP_BOUNDS, CONFLICT_COLORS } from '$lib/constants';
 
 describe('parseTimeToMinutes', () => {
     it('parses noon', () => {
@@ -234,5 +241,289 @@ describe('countdownColor', () => {
 
     it('clamps fraction below 0 to gray', () => {
         expect(countdownColor(-0.5)).toBe(COUNTDOWN_GRAY);
+    });
+});
+
+describe('formatTime12', () => {
+    it('converts afternoon hour correctly', () => {
+        expect(formatTime12('14:30')).toBe('2:30');
+    });
+
+    it('keeps noon as 12:00', () => {
+        expect(formatTime12('12:00')).toBe('12:00');
+    });
+
+    it('converts midnight to 12:00', () => {
+        expect(formatTime12('00:00')).toBe('12:00');
+    });
+
+    it('preserves morning hours as-is', () => {
+        expect(formatTime12('11:00')).toBe('11:00');
+    });
+
+    it('zero-pads minutes', () => {
+        expect(formatTime12('13:05')).toBe('1:05');
+    });
+
+    it('converts 22:00 to 10:00', () => {
+        expect(formatTime12('22:00')).toBe('10:00');
+    });
+});
+
+describe('pickedActsForDay', () => {
+    const locations = new Map([
+        ['Stage A', { lat: 29.955, lng: -90.063 }],
+        ['Stage B', { lat: 29.96, lng: -90.058 }]
+    ]);
+
+    const THU = '2026-04-16';
+    const FRI = '2026-04-17';
+
+    const acts: ActSummary[] = [
+        {
+            slug: 'thu-a',
+            name: 'Thu A',
+            stage: 'Stage A',
+            date: THU,
+            start: '14:00',
+            end: '15:00',
+            genre: 'Jazz (Traditional)'
+        },
+        {
+            slug: 'thu-b',
+            name: 'Thu B',
+            stage: 'Stage B',
+            date: THU,
+            start: '12:00',
+            end: '13:00',
+            genre: 'Blues'
+        },
+        {
+            slug: 'fri-a',
+            name: 'Fri A',
+            stage: 'Stage A',
+            date: FRI,
+            start: '11:00',
+            end: '12:00',
+            genre: 'Funk'
+        }
+    ];
+
+    it('returns only picked acts for the target date', () => {
+        const picks = new Set(['thu-a', 'thu-b', 'fri-a']);
+        const result = pickedActsForDay(acts, picks, THU, locations);
+        expect(result.map((a) => a.slug)).toEqual(['thu-b', 'thu-a']);
+    });
+
+    it('excludes unpicked acts', () => {
+        const picks = new Set(['thu-a']);
+        const result = pickedActsForDay(acts, picks, THU, locations);
+        expect(result.map((a) => a.slug)).toEqual(['thu-a']);
+    });
+
+    it('excludes acts from other dates', () => {
+        const picks = new Set(['thu-a', 'fri-a']);
+        const result = pickedActsForDay(acts, picks, THU, locations);
+        expect(result.map((a) => a.slug)).toEqual(['thu-a']);
+    });
+
+    it('returns empty array when no picks match date', () => {
+        const picks = new Set(['fri-a']);
+        const result = pickedActsForDay(acts, picks, THU, locations);
+        expect(result).toHaveLength(0);
+    });
+
+    it('sorts by start time then stage latitude when times match', () => {
+        const tieActs: ActSummary[] = [
+            {
+                slug: 'high-lat',
+                name: 'High',
+                stage: 'Stage B',
+                date: THU,
+                start: '14:00',
+                end: '15:00',
+                genre: 'Jazz (Traditional)'
+            },
+            {
+                slug: 'low-lat',
+                name: 'Low',
+                stage: 'Stage A',
+                date: THU,
+                start: '14:00',
+                end: '15:00',
+                genre: 'Blues'
+            }
+        ];
+        const picks = new Set(['high-lat', 'low-lat']);
+        const result = pickedActsForDay(tieActs, picks, THU, locations);
+        // Stage A lat=29.955 < Stage B lat=29.96, so Stage A comes first
+        expect(result[0].slug).toBe('low-lat');
+        expect(result[1].slug).toBe('high-lat');
+    });
+});
+
+describe('buildScheduleMarkers', () => {
+    const locations = new Map([
+        ['Stage A', { lat: 29.955, lng: -90.063 }],
+        ['Stage B', { lat: 29.96, lng: -90.058 }]
+    ]);
+
+    const orderedActs: ActSummary[] = [
+        {
+            slug: 'act-1',
+            name: 'First',
+            stage: 'Stage A',
+            date: '2026-04-16',
+            start: '11:00',
+            end: '12:00',
+            genre: 'Jazz (Traditional)'
+        },
+        {
+            slug: 'act-2',
+            name: 'Second',
+            stage: 'Stage B',
+            date: '2026-04-16',
+            start: '13:00',
+            end: '14:00',
+            genre: 'Blues'
+        }
+    ];
+
+    it('assigns order 1 to first act', () => {
+        const markers = buildScheduleMarkers(orderedActs, locations);
+        expect(markers[0].order).toBe(1);
+        expect(markers[0].isFirst).toBe(true);
+    });
+
+    it('assigns sequential order numbers', () => {
+        const markers = buildScheduleMarkers(orderedActs, locations);
+        expect(markers.map((m) => m.order)).toEqual([1, 2]);
+    });
+
+    it('marks only first act as isFirst', () => {
+        const markers = buildScheduleMarkers(orderedActs, locations);
+        expect(markers[0].isFirst).toBe(true);
+        expect(markers[1].isFirst).toBe(false);
+    });
+
+    it('skips acts with no stage location', () => {
+        const actsWithUnknownStage: ActSummary[] = [
+            { ...orderedActs[0], stage: 'Unknown Stage' },
+            orderedActs[1]
+        ];
+        const markers = buildScheduleMarkers(actsWithUnknownStage, locations);
+        expect(markers).toHaveLength(1);
+        expect(markers[0].act.slug).toBe('act-2');
+    });
+
+    it('detects overlap conflict between acts', () => {
+        const conflictingActs: ActSummary[] = [
+            {
+                slug: 'c1',
+                name: 'C1',
+                stage: 'Stage A',
+                date: '2026-04-16',
+                start: '11:00',
+                end: '13:00',
+                genre: 'Jazz (Traditional)'
+            },
+            {
+                slug: 'c2',
+                name: 'C2',
+                stage: 'Stage B',
+                date: '2026-04-16',
+                start: '12:00',
+                end: '14:00',
+                genre: 'Blues'
+            }
+        ];
+        const markers = buildScheduleMarkers(conflictingActs, locations);
+        expect(markers[0].conflict).toBe('red');
+        expect(markers[1].conflict).toBe('red');
+    });
+
+    it('has no conflict for non-overlapping acts', () => {
+        const markers = buildScheduleMarkers(orderedActs, locations);
+        expect(markers[0].conflict).toBe('none');
+        expect(markers[1].conflict).toBe('none');
+    });
+});
+
+describe('buildPathArrows', () => {
+    // Stage A ≈ 29.955,-90.063 and Stage B ≈ 29.96,-90.058 are ~750m apart
+    const locations = new Map([
+        ['Stage A', { lat: 29.955, lng: -90.063 }],
+        ['Stage B', { lat: 29.96, lng: -90.058 }]
+    ]);
+
+    const farActs: ActSummary[] = [
+        {
+            slug: 'a',
+            name: 'A',
+            stage: 'Stage A',
+            date: '2026-04-16',
+            start: '11:00',
+            end: '12:00',
+            genre: 'Jazz (Traditional)'
+        },
+        {
+            slug: 'b',
+            name: 'B',
+            stage: 'Stage B',
+            date: '2026-04-16',
+            start: '13:00',
+            end: '14:00',
+            genre: 'Blues'
+        }
+    ];
+
+    const sameStageActs: ActSummary[] = [
+        { ...farActs[0], slug: 'x1' },
+        { ...farActs[1], slug: 'x2', stage: 'Stage A' }
+    ];
+
+    it('draws an arrow between stages that are far apart', () => {
+        const arrows = buildPathArrows(farActs, locations);
+        expect(arrows).toHaveLength(1);
+    });
+
+    it('skips arrow when acts are at the same stage (distance = 0)', () => {
+        const arrows = buildPathArrows(sameStageActs, locations);
+        expect(arrows).toHaveLength(0);
+    });
+
+    it('records the distance in meters', () => {
+        const arrows = buildPathArrows(farActs, locations);
+        expect(arrows[0].distanceMeters).toBeGreaterThan(MIN_PATH_DISTANCE_METERS);
+    });
+
+    it('returns empty array for a single act', () => {
+        const arrows = buildPathArrows([farActs[0]], locations);
+        expect(arrows).toHaveLength(0);
+    });
+
+    it('skips acts with missing location', () => {
+        const actsWithUnknown: ActSummary[] = [{ ...farActs[0], stage: 'Unknown' }, farActs[1]];
+        const arrows = buildPathArrows(actsWithUnknown, locations);
+        expect(arrows).toHaveLength(0);
+    });
+});
+
+describe('markerFillColor', () => {
+    it('returns purple for first marker regardless of conflict', () => {
+        expect(markerFillColor(true, 'red')).toBe(SCHEDULE_MARKER_PURPLE);
+        expect(markerFillColor(true, 'none')).toBe(SCHEDULE_MARKER_PURPLE);
+    });
+
+    it('returns green for non-first with no conflict', () => {
+        expect(markerFillColor(false, 'none')).toBe(CONFLICT_COLORS.none);
+    });
+
+    it('returns yellow for non-first with yellow conflict', () => {
+        expect(markerFillColor(false, 'yellow')).toBe(CONFLICT_COLORS.yellow);
+    });
+
+    it('returns red for non-first with red conflict', () => {
+        expect(markerFillColor(false, 'red')).toBe(CONFLICT_COLORS.red);
     });
 });

--- a/ui/src/lib/map-utils.ts
+++ b/ui/src/lib/map-utils.ts
@@ -3,8 +3,14 @@
  * countdown color interpolation, and time formatting.
  */
 
-import type { ActSummary } from '$lib/types';
-import { MAP_BOUNDS, MAX_LOOKAHEAD_MINUTES, MINUTES_PER_HOUR } from '$lib/constants';
+import type { ActSummary, ConflictLevel } from '$lib/types';
+import {
+    MAP_BOUNDS,
+    MAX_LOOKAHEAD_MINUTES,
+    MINUTES_PER_HOUR,
+    CONFLICT_COLORS
+} from '$lib/constants';
+import { haversineMeters } from '$lib/distance';
 
 // Countdown color endpoints: gray (inactive) ↔ dark green (active)
 export const COUNTDOWN_GRAY = '#999999';
@@ -33,6 +39,16 @@ export function formatTimeDisplay(minutes: number): string {
     const period = h >= NOON_HOUR ? 'PM' : 'AM';
     const h12 = h > NOON_HOUR ? h - NOON_HOUR : h === 0 ? NOON_HOUR : h;
     return `${h12}:${m.toString().padStart(2, '0')} ${period}`;
+}
+
+/**
+ * Format an "HH:MM" 24-hour time string to 12-hour without AM/PM suffix.
+ * E.g. "14:30" → "2:30", "11:00" → "11:00".
+ */
+export function formatTime12(hhmm: string): string {
+    const [h, m] = hhmm.split(':').map(Number);
+    const h12 = h > NOON_HOUR ? h - NOON_HOUR : h === 0 ? NOON_HOUR : h;
+    return `${h12}:${m.toString().padStart(2, '0')}`;
 }
 
 // ── Coordinate conversion ───────────────────────────────────────────────
@@ -147,4 +163,120 @@ export function countdownColor(fraction: number): string {
         Math.round(g1 + (g2 - g1) * t),
         Math.round(b1 + (b2 - b1) * t)
     );
+}
+
+// ── My Schedule map mode ────────────────────────────────────────────────
+
+/** Minimum straight-line distance (meters) before drawing a path arrow. */
+export const MIN_PATH_DISTANCE_METERS = 61; // ≈ 200 feet
+
+export const SCHEDULE_MARKER_PURPLE = '#7c3aed';
+
+export interface ScheduleMarker {
+    act: ActSummary;
+    order: number; // 1-based chronological index
+    conflict: ConflictLevel;
+    pos: { x: number; y: number }; // CSS % position
+    isFirst: boolean;
+}
+
+export interface PathArrow {
+    from: { x: number; y: number };
+    to: { x: number; y: number };
+    distanceMeters: number;
+}
+
+/**
+ * Return picked acts for a specific date, sorted by start time then stage
+ * latitude (ascending) when start times are equal.
+ */
+export function pickedActsForDay(
+    allActs: ActSummary[],
+    picks: Set<string>,
+    date: string,
+    stageLocations: Map<string, { lat: number; lng: number }>
+): ActSummary[] {
+    return allActs
+        .filter((a) => picks.has(a.slug) && a.date === date)
+        .sort((a, b) => {
+            const timeDiff = parseTimeToMinutes(a.start) - parseTimeToMinutes(b.start);
+            if (timeDiff !== 0) return timeDiff;
+            const aLat = stageLocations.get(a.stage)?.lat ?? 0;
+            const bLat = stageLocations.get(b.stage)?.lat ?? 0;
+            return aLat - bLat;
+        });
+}
+
+/**
+ * Build the ordered marker list for My Schedule mode.
+ * Conflict level for each act is computed against all other picked acts on the same day.
+ */
+export function buildScheduleMarkers(
+    orderedActs: ActSummary[],
+    stageLocations: Map<string, { lat: number; lng: number }>
+): ScheduleMarker[] {
+    return orderedActs
+        .map((act, i) => {
+            const loc = stageLocations.get(act.stage);
+            if (!loc) return null;
+            const conflict = computeConflictForAct(act, orderedActs);
+            return {
+                act,
+                order: i + 1,
+                conflict,
+                pos: latLngToPercent(loc.lat, loc.lng),
+                isFirst: i === 0
+            };
+        })
+        .filter((m): m is ScheduleMarker => m !== null);
+}
+
+/** Compute worst conflict level for an act against the other acts in the list. */
+function computeConflictForAct(act: ActSummary, allPickedActs: ActSummary[]): ConflictLevel {
+    const s1 = parseTimeToMinutes(act.start);
+    const e1 = parseTimeToMinutes(act.end);
+    let worst: ConflictLevel = 'none';
+    for (const other of allPickedActs) {
+        if (other.slug === act.slug) continue;
+        const s2 = parseTimeToMinutes(other.start);
+        const e2 = parseTimeToMinutes(other.end);
+        const overlap = Math.max(0, Math.min(e1, e2) - Math.max(s1, s2));
+        if (overlap > 0) {
+            worst = 'red';
+            break;
+        }
+    }
+    return worst;
+}
+
+/**
+ * Build path arrows between consecutive acts in the schedule.
+ * Only draws an arrow when the straight-line distance exceeds MIN_PATH_DISTANCE_METERS.
+ */
+export function buildPathArrows(
+    orderedActs: ActSummary[],
+    stageLocations: Map<string, { lat: number; lng: number }>
+): PathArrow[] {
+    const arrows: PathArrow[] = [];
+    for (let i = 0; i < orderedActs.length - 1; i++) {
+        const fromAct = orderedActs[i];
+        const toAct = orderedActs[i + 1];
+        const fromLoc = stageLocations.get(fromAct.stage);
+        const toLoc = stageLocations.get(toAct.stage);
+        if (!fromLoc || !toLoc) continue;
+        const distMeters = haversineMeters(fromLoc.lat, fromLoc.lng, toLoc.lat, toLoc.lng);
+        if (distMeters <= MIN_PATH_DISTANCE_METERS) continue;
+        arrows.push({
+            from: latLngToPercent(fromLoc.lat, fromLoc.lng),
+            to: latLngToPercent(toLoc.lat, toLoc.lng),
+            distanceMeters: distMeters
+        });
+    }
+    return arrows;
+}
+
+/** Marker fill color based on conflict level. First act is always purple. */
+export function markerFillColor(isFirst: boolean, conflict: ConflictLevel): string {
+    if (isFirst) return SCHEDULE_MARKER_PURPLE;
+    return CONFLICT_COLORS[conflict];
 }

--- a/ui/src/routes/fq2026/+page.svelte
+++ b/ui/src/routes/fq2026/+page.svelte
@@ -115,10 +115,11 @@
         const date = appState.selectedDate;
         const mode = appState.viewMode;
 
-        if ((mode === 'my-schedule' || mode === 'share') && !allActsLoaded) {
+        if ((mode === 'my-schedule' || mode === 'share' || mode === 'map') && !allActsLoaded) {
             loadAllActs();
-        } else if (
-            (mode === 'grid' || mode === 'mobile') &&
+        }
+        if (
+            (mode === 'grid' || mode === 'mobile' || mode === 'map') &&
             (date !== prevDate || mode !== prevViewMode)
         ) {
             prevDate = date;
@@ -201,7 +202,17 @@
                 onActDetail={openDetail}
             />
         {:else if appState.viewMode === 'map'}
-            <MapView {acts} {stageLocations} onActDetail={openDetail} />
+            <MapView
+                {acts}
+                {allActs}
+                picks={appState.picks}
+                selectedDate={appState.selectedDate}
+                {stageLocations}
+                onActDetail={openDetail}
+                onDayChange={(d) => {
+                    appState.selectedDate = d;
+                }}
+            />
         {:else if appState.viewMode === 'share'}
             <ShareView selfActs={allActs} />
         {:else if loading}


### PR DESCRIPTION
## Summary

- Adds a map control bar with day selector and triple radio (`Scroll Time / Now / My Schedule`) replacing the old single checkbox
- **My Schedule mode**: shows only stages with picks for the selected day; each act gets a numbered circle marker (purple for first, conflict-colored for rest) with a `start–end Name` label
- **Show Paths**: optional toggle (only in My Schedule mode) that draws purple dashed arrows with distance labels between consecutive acts when stages are >200ft apart
- Time displays throughout MapView now use 12-hour format without AM/PM suffix (`2:30` not `14:30`)

## Technical changes

- `map-utils.ts`: added `formatTime12`, `pickedActsForDay`, `buildScheduleMarkers`, `buildPathArrows`, `markerFillColor`, and related types/constants
- `MapView.svelte`: complete control bar redesign; three rendering modes; SVG path overlay; accepts new `allActs`, `picks`, `selectedDate`, `onDayChange` props
- `+page.svelte`: passes new props to MapView; loads `allActs` when map view is active (needed for My Schedule sub-mode); day changes in the map also refresh `acts` for Scroll/Now modes
- `map-utils.test.ts`: 26 new tests covering all new utility functions (98 total, all passing)

## Test plan

- [ ] Switch to Map view — day tabs appear in the control bar, Scroll Time is default
- [ ] Drag time slider — stage markers update as before
- [ ] Select Now — live clock label appears, markers reflect current time
- [ ] Select My Schedule — numbered markers appear only for picked acts on that day
- [ ] First marker is larger and purple; subsequent markers are green/yellow/red per conflict
- [ ] Check Show Paths — purple dashed arrows with distance labels connect consecutive acts
- [ ] Acts at the same stage produce no arrow
- [ ] Clicking a marker opens the act detail modal
- [ ] Changing day in the map control updates both scroll/now acts and My Schedule acts
- [ ] `pnpm test --run` → 98 tests pass
- [ ] `pnpm lint` → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
